### PR TITLE
Add GTM head and body code in public/index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,8 +38,20 @@
     <meta name="twitter:title" content="AppOrigo Technologies" />
     <meta name="twitter:description" content="Crafting digital experiences that transform businesses and inspire innovation." />
     <meta name="twitter:image" content="https://apporigotechnologies.co.in/og-image.jpg" />
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-55B2HK3L');</script>
+    <!-- End Google Tag Manager -->
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-55B2HK3L"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--


### PR DESCRIPTION
This PR adds the Google Tag Manager script in the head and body sections of the public/index.html file to enable GA4 tracking for the website. No other changes were made.